### PR TITLE
Fix two errors

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -642,7 +642,7 @@ function get_shared_participants($courseid, $fullcourse = false, $enrolled = nul
 
             foreach ($user as $us) {
 
-                $usersbyrole[$us->id] = fullname($user);
+                $usersbyrole[$us->id] = fullname($us);
             }
 
         }

--- a/renderer.php
+++ b/renderer.php
@@ -110,7 +110,7 @@ function renderer_output_myeportfolios($tsort = '', $tdir = '') {
             // Add a hint if file is uploaded/shared as template and an undo icon to stop sharing as template.
             $istemplatefile = '';
 
-            if ($ent['istemplate']) {
+            if (!empty($ent['istemplate'])) {
 
                 $istemplatefile = html_writer::tag('i', '', array('class' => 'fa fa-info-circle ml-3', 'data-toggle' => 'tooltip',
                         'data-placement' => 'right', 'title' => get_string('overview:table:istemplate', 'local_eportfolio')));


### PR DESCRIPTION
Unser Testszenario war:

Ich arbeite mit drei Testnutzern: testnutzer1 (TN), testnutzer2 (Trainer), testnutzer3 (TN) in drei Kursen eportfolio 1, 2 und 3. 
testnutzer3 hat ein Portfolio in Kurs eportfolio2 geteilt. 
Dann ändert testnutzer3 das Teilen auf Kurs eportfolio3. 
testnutzer1 erhält diese Fehlermeldung beim Anklicken des Kurses: 
"core_user::get_fullname(): Argument #1 ($user) must be of type stdClass, array given, called in [dirroot]/lib/moodlelib.php on line 3653"
