### PR TITLE
Add templates to myshared overview and make shareoption column sortable

### DIFF
--- a/classes/local/overview.php
+++ b/classes/local/overview.php
@@ -88,7 +88,6 @@ class overview {
             $table->define_baseurl($this->url);
             $table->set_attribute('class', 'table table-hover');
             $table->sortable(true, 'filename', SORT_ASC);
-            $table->sortable(true, 'shareoption', SORT_ASC);
             $table->initialbars(true);
             $table->no_sorting('actions');
             $table->no_sorting('filesize');

--- a/classes/local/overview.php
+++ b/classes/local/overview.php
@@ -88,6 +88,7 @@ class overview {
             $table->define_baseurl($this->url);
             $table->set_attribute('class', 'table table-hover');
             $table->sortable(true, 'filename', SORT_ASC);
+            $table->sortable(true, 'shareoption', SORT_ASC);
             $table->initialbars(true);
             $table->no_sorting('actions');
             $table->no_sorting('filesize');
@@ -191,8 +192,13 @@ class overview {
                 $whereclauses[] = 'usermodified = :usermodified';
                 break;
             case 'myshared': // My ePortfolios shared for viewing.
-                $params['shareoption'] = 'share';
-                $whereclauses[] = 'shareoption = :shareoption';
+                //$params['shareoption'] = 'share';
+                //$whereclauses[] = 'shareoption = :shareoption';
+                // NEW
+                $params['shareoption1'] = 'share';
+                $params['shareoption2'] = 'template';
+                $whereclauses[] = '(shareoption = :shareoption1 OR shareoption = :shareoption2)';
+                // END
                 $params['usermodified'] = (int) $USER->id;
                 $whereclauses[] = 'usermodified = :usermodified';
                 break;
@@ -247,6 +253,8 @@ class overview {
                 $orderbyfield = 'timecreated';
             } else if ($this->tsort === 'shareend') {
                 $orderbyfield = 'enddate';
+            } else if ($this->tsort === 'shareoption') {
+                $orderbyfield = 'shareoption';
             }
 
             $sortorder = " ORDER BY " . $orderbyfield . " " . $orderby;
@@ -322,6 +330,7 @@ class overview {
                 $columns = [
                         'filename',
                         'filetimemodified',
+                        'shareoption',
                         'filesize',
                         'coursefullname',
                         'participants',
@@ -393,6 +402,7 @@ class overview {
                 $headers = [
                         get_string('overview:table:filename', 'local_eportfolio'),
                         get_string('overview:table:filetimemodified', 'local_eportfolio'),
+                        get_string('overview:table:shareoption', 'local_eportfolio'),
                         get_string('overview:table:filesize', 'local_eportfolio'),
                         get_string('overview:table:coursefullname', 'local_eportfolio'),
                         get_string('overview:table:participants', 'local_eportfolio'),
@@ -575,6 +585,7 @@ class overview {
                         \html_writer::link($viewurl, $filename,
                                 ['title' => get_string('overview:table:viewfile', 'local_eportfolio')]),
                         date('d.m.Y', $ent->timemodified),
+                        get_string('overview:shareoption:' . $ent->shareoption, 'local_eportfolio'),
                         $filesize,
                         $courseurlfull,
                         $sharedwith,

--- a/lang/de/local_eportfolio.php
+++ b/lang/de/local_eportfolio.php
@@ -76,6 +76,7 @@ $string['overview:table:selection'] = 'Auswahl';
 $string['overview:table:filename'] = 'Dateiname';
 $string['overview:table:filetimecreated'] = 'Angelegt am';
 $string['overview:table:filetimemodified'] = 'Aktualisiert am';
+$string['overview:table:shareoption'] = 'Freigabetyp';
 $string['overview:table:filesize'] = 'Größe';
 $string['overview:table:coursefullname'] = 'Geteilt im Kurs';
 $string['overview:table:instancename'] = 'Aktivität';

--- a/lang/en/local_eportfolio.php
+++ b/lang/en/local_eportfolio.php
@@ -75,6 +75,7 @@ $string['overview:table:selection'] = 'Select';
 $string['overview:table:filename'] = 'Filename';
 $string['overview:table:filetimecreated'] = 'Created/Uploaded';
 $string['overview:table:filetimemodified'] = 'Last modified';
+$string['overview:table:shareoption'] = 'Sharedoption';
 $string['overview:table:filesize'] = 'Filesize';
 $string['overview:table:coursefullname'] = 'Shared in course';
 $string['overview:table:instancename'] = 'Course module';


### PR DESCRIPTION
Add templates to myshared overview
The shareoption column has been added to the table headers.
The shareoption column is now sortable by the user, but no longer pre-selected as the default sort.